### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ jobs:
           # This is critically important!
           # The action won't work without this
           fetch-depth: 0
-      - name: Run self
-        uses: Kixunil/mkchlog-action
+      - name: Check changelog
+        uses: Kixunil/mkchlog-action@master
 ```


### PR DESCRIPTION
The configuration requires use of `@ref`, so this adds it. Also makes the name of the action nicer.